### PR TITLE
안드로이드 targetSDK33 변경 후 발생하는 컴파일 에러 수정

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java
@@ -698,7 +698,15 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
                         + photoUri.toString(),
                 e);
       }
-      retriever.release();
+
+      try {
+        retriever.release();
+      } catch (Exception e) {
+        FLog.e(
+          ReactConstants.TAG,
+          "Error while releasing retriever",
+          e);
+      }
     }
 
     if (photoDescriptor != null) {
@@ -765,7 +773,15 @@ public class CameraRollModule extends ReactContextBaseJavaModule {
                             + photoUri.toString(),
                     e);
           }
-          retriever.release();
+       
+          try {
+            retriever.release();
+          } catch (Exception e) {
+            FLog.e(
+                ReactConstants.TAG,
+                "Error while releasing retriever",
+                e);
+          }
         } else {
           BitmapFactory.Options options = new BitmapFactory.Options();
           // Set inJustDecodeBounds to true so we don't actually load the Bitmap, but only get its


### PR DESCRIPTION
release 시 에러가 발생하면 IOException을 throw 하도록 변경됨
https://developer.android.com/sdk/api_diff/33/changes

try catch로 감싸도록 수정